### PR TITLE
add IPMI_READ_INTERVAL env variable

### DIFF
--- a/controller.py
+++ b/controller.py
@@ -29,7 +29,7 @@ def main():
     tempController = TemperatureController(config, ipmitool)
 
     # TODO: better
-    intervals = 30.0
+    intervals = os.getenv('IPMI_READ_INTERVAL', 30)
     starttime = time.time()
 
     while True:


### PR DESCRIPTION
Set the read interval from an environmental variable with a default of 30s if that variable is undefined.